### PR TITLE
Override testcontainers version to v1.21.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
     <properties>
         <gridsuite-dependencies.version>47.0.0</gridsuite-dependencies.version>
         <jib.from.image>powsybl/java-dynawo:3.1.0</jib.from.image>
+        <!-- FIXME to remove when upgrade powsybl-ws-dependencies to springboot 3.5.9 -->
+        <testcontainers.version>1.21.4</testcontainers.version>
         <liquibase-hibernate-package>org.gridsuite.dynamicmargincalculation.server</liquibase-hibernate-package>
         <sonar.organization>gridsuite</sonar.organization>
         <sonar.projectKey>org.gridsuite:dynamic-margin-calculation-server</sonar.projectKey>
@@ -86,6 +88,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- overrides of imports -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers</artifactId>
+                <version>${testcontainers.version}</version>
+            </dependency>
 
             <!-- imports -->
             <dependency>


### PR DESCRIPTION
## PR Summary
Override to testcontainers v1.21.4 to fix github CI. See https://github.com/testcontainers/testcontainers-java/issues/11212

Actual testcontainers version taken by springboot 3.4.9 is 1.20.6



